### PR TITLE
Refactor: Implement stricter filtering and preview truncation

### DIFF
--- a/florida_man_stories.json
+++ b/florida_man_stories.json
@@ -1,62 +1,6 @@
 {
-  "last_updated": "2025-05-24T00:42:26.550737",
+  "last_updated": "2025-05-24T00:44:15.638707",
   "stories": [
-    {
-      "title": "Firefighters rescue seniors trapped in \u2018heavy smoke\u2019 in Little Havana apartment fire",
-      "link": "https://www.local10.com/news/local/2025/05/24/firefighters-rescue-seniors-trapped-in-little-havana-apartment-fire/",
-      "preview": "Miami Fire Rescue crews rescued two seniors trapped in a smoke-filled apartment in the city\u2019s Little Havana neighborhood Friday evening.",
-      "source": "https://www.local10.com/news/florida/",
-      "date": "2025-05-24T00:01:48",
-      "location": "Miami"
-    },
-    {
-      "title": "Above-average Atlantic hurricane season predicted for 2025",
-      "link": "https://www.orlandoweekly.com/news/above-average-atlantic-hurricane-season-predicted-for-2025-39585642",
-      "preview": "<img height=\"800\" src=\"https://media2.orlandoweekly.com/orlando/imager/u/magnum/39585661/shutterstock_1256683165.webp?cb=1748025965\" width=\"1200\" />\n          Hurricane experts from the National Oceanic and Atmospheric Administration expect an above-average storm season in 2025, according to a forecast released Thursday. NOAA\u2019s outlook for the Atlantic hurricane season, which will run from June 1 to Nov. 30, anticipates 13 to 19 named storms with winds topping 39 mph, with six to 10 packing hurricane-strength winds sustained at 74 mph or higher. The agency also forecast three to five major hurricanes, with winds of 111 mph or higher.",
-      "source": "https://www.orlandoweekly.com/news",
-      "date": "2025-05-23T18:45:00",
-      "location": "Orlando"
-    },
-    {
-      "title": "Animal Advocates Aim to End Florida's Cockfighting Rings",
-      "link": "https://www.miaminewtimes.com/news/animal-advocates-aim-to-end-floridas-cockfighting-rings-23164535",
-      "preview": "<img height=\"573\" src=\"https://media2.miaminewtimes.com/mia/imager/u/blog/23188052/adam_cohn.webp?cb=1748038600\" width=\"860\" />\n      Local law enforcement recently arrested 42 people in connection with a brutal backyard cockfighting ring, exposing a violent network of animal trafficking, postal smuggling, and high-stakes gambling tied to the blood sport, Animal Wellness Action president Wayne Pacelle tells New Times. Miami-Dade Sheriff's Office (MDSO) deputies responded to a group of men wielding machetes and knives in the 14000 block of SW 192nd Avenue, according to reports\u2026",
-      "source": "https://www.miaminewtimes.com/news",
-      "date": "2025-05-23T17:25:00",
-      "location": "Miami"
-    },
-    {
-      "title": "Fort Lauderdale Airbnb Shooting: Rental Had History of Complaints",
-      "link": "https://www.miaminewtimes.com/news/fort-lauderdale-airbnb-shooting-rental-had-history-of-complaints-23166002",
-      "preview": "<img height=\"425\" src=\"https://media2.miaminewtimes.com/mia/imager/u/blog/23168348/airbnbshooting_youtube_scjpeg.webp?cb=1748016028\" width=\"860\" />\n      A Fort Lauderdale Airbnb at the center of a fatal shooting earlier this week appears to have caught the attention of neighbors for loud parties in the months leading up to the incident. On Monday, May 19, at 4:30 a.m\u2026",
-      "source": "https://www.miaminewtimes.com/news",
-      "date": "2025-05-23T16:01:00",
-      "location": "Miami"
-    },
-    {
-      "title": "Florida owners of \u2018dangerous\u2019 dogs will need $100,000 liability insurance under bill signed by DeSantis",
-      "link": "https://www.orlandoweekly.com/news/florida-owners-of-dangerous-dogs-will-need-100000-liability-insurance-under-bill-signed-by-desantis-39584388",
-      "preview": "<img height=\"800\" src=\"https://media1.orlandoweekly.com/orlando/imager/u/magnum/39584413/shutterstock_2157512391.webp?cb=1748012340\" width=\"1200\" />\n       Gov. Ron DeSantis signed a law Wednesday bringing harsher penalties and restrictions for owners of dogs that severely injure or kill people. The bill, known as the \u201cPam Rock Act,\u201d honors a mail carrier who was mauled to death by five dogs in Putnam County in 2022.",
-      "source": "https://www.orlandoweekly.com/news",
-      "date": "2025-05-23T14:59:00",
-      "location": "Orlando"
-    },
-    {
-      "title": "DeSantis quietly signs bill to bar golf courses, hotels in Florida state parks",
-      "link": "https://www.orlandoweekly.com/news/desantis-quietly-signs-bill-to-bar-golf-courses-hotels-in-state-parks-39584391",
-      "preview": "<img height=\"675\" src=\"https://media1.orlandoweekly.com/orlando/imager/u/magnum/39584403/0-3-1-2048x1152.webp?cb=1748011906\" width=\"1200\" />\n         Gov. Ron DeSantis on Thursday signed a bill born out of the backlash against his administration\u2019s plan last summer to build golf courses, hotels, and pickleball courts at nine state parks. The Legislature unanimously approved HB 209, which prohibits construction of specified sporting facilities and public lodgings in state parks, such as golf courses, tennis courts, pickleball courts, and ball fields. Southeast Republican Rep. John Snyder pitched the proposal following backlash and protests from Republicans and Democrats alike, who opposed the Florida Department of Environmental Protection\u2019s leaked plan to build such facilities.",
-      "source": "https://www.orlandoweekly.com/news",
-      "date": "2025-05-23T14:51:00",
-      "location": "Orlando"
-    },
-    {
-      "title": "The Electronic Frontier Foundation looks back at the games governments played to avoid transparency",
-      "link": "https://www.orlandoweekly.com/news/the-electronic-frontier-foundation-looks-back-at-the-games-governments-played-to-avoid-transparency-39580113",
-      "preview": "<img height=\"691\" src=\"https://media2.orlandoweekly.com/orlando/imager/u/magnum/39583848/cover_nakamoto.webp?cb=1748004903\" width=\"1200\" />\n      In the year 2015, we witnessed the launch of OpenAI, a debate over the color of a dress going viral, and a Supreme Court decision that same-sex couples have the right to get married. It was also the year that the Electronic Frontier Foundation first published The Foilies, an annual report that hands out tongue-in-cheek \u201cawards\u201d to government agencies and officials that respond outrageously when a member of the public tries to access public records through the Freedom of Information Act (FOIA) or similar laws. A lot has changed over the last decade, but one thing that hasn\u2019t is the steady flow of attempts by authorities to avoid their legal and ethical obligations to be open and accountable.",
-      "source": "https://www.orlandoweekly.com/news",
-      "date": "2025-05-23T12:55:00",
-      "location": "Orlando"
-    },
     {
       "title": "Florida woman charged after allegedly attacking 72-year-old Trump supporter wearing MAGA hat",
       "link": "https://www.foxnews.com/us/florida-woman-charged-allegedly-attacking-72-year-old-trump-supporter-wearing-maga-hat",
@@ -64,22 +8,6 @@
       "source": "https://www.foxnews.com/category/us/us-regions/southeast/florida",
       "date": "2025-05-23T06:24:32",
       "location": "Florida"
-    },
-    {
-      "title": "Doral Mayor Pushes Back On \u2018Harsh' Temporary Protected Status Move",
-      "link": "https://www.miaminewtimes.com/news/doral-mayor-pushes-back-on-harsh-temporary-protected-status-move-23176620",
-      "preview": "<img height=\"538\" src=\"https://media2.miaminewtimes.com/mia/imager/u/blog/23178824/migrants-in-us-credit-u.s.-department-of-homeland-security.jpg.webp?cb=1747949781\" width=\"860\" />\n      Venezuelan refugees who are fearing a forced return to their country are feeling the repercussions of immigration policies set by the previous administration, Doral Mayor Christi Fraga tells New Times. Fraga was referring to a Monday Supreme Court decision to suspend the temporary protected status (TPS) of about 350,000 Venezuelans living in the United States\u2026",
-      "source": "https://www.miaminewtimes.com/news",
-      "date": "2025-05-22T19:03:00",
-      "location": "Miami"
-    },
-    {
-      "title": "New Florida Hurricane Season Forecast Released: What to Expect",
-      "link": "https://www.miaminewtimes.com/news/2025-florida-hurricane-forecast-calls-for-active-season-23178215",
-      "preview": "<img height=\"476\" src=\"https://media2.miaminewtimes.com/mia/imager/u/blog/23179262/image-hurricane-milton-goes-16-100824-noaa_0.webp?cb=1747943672\" width=\"860\" />\n      Once again, weather forecasters are expecting another above-normal\u00a0hurricane season. On May 22, the National Oceanic and Atmospheric Administration (NOAA) released its 2025 Atlantic hurricane season outlook, which predicts a 60 percent chance of an above-normal season\u2026",
-      "source": "https://www.miaminewtimes.com/news",
-      "date": "2025-05-22T19:02:00",
-      "location": "Miami"
     }
   ]
 }

--- a/scraper.py
+++ b/scraper.py
@@ -22,9 +22,7 @@ rss_sources = [
 
 def is_florida_man_story(title, text):
     keywords = [
-        "florida man", "florida woman", "florida resident", "florida person", 
-        "a florida", "gainesville", "jacksonville", "miami", "orlando", "tampa", 
-        "arrested in florida", "florida sheriff", "bizarre florida", "strange florida"
+        "florida man", "florida woman"
     ]
     title_lower = title.lower()
     text_lower = text.lower()
@@ -77,10 +75,17 @@ def scrape_stories():
                     continue
 
                 if is_florida_man_story(title, preview):
+                    # Truncate preview to 4 lines
+                    lines = preview.split('\n')
+                    if len(lines) > 4:
+                        truncated_preview = '\n'.join(lines[:4])
+                    else:
+                        truncated_preview = preview
+
                     story = {
                         'title': title,
                         'link': link,
-                        'preview': preview,
+                        'preview': truncated_preview,
                         'source': source_info['original_url'], # Use original website URL
                         'date': story_date_iso,
                         'location': extract_florida_location(title + " " + preview)


### PR DESCRIPTION
This commit updates the scraper based on your feedback to:

1.  Apply stricter keyword filtering:
    - The `is_florida_man_story` function now only matches stories containing the exact phrases "florida man" or "florida woman" (case-insensitive) in their title or summary.
    - This makes the story selection much more targeted to the specific "Florida Man" phenomenon.

2.  Truncate story previews:
    - The `preview` field for each story in `florida_man_stories.json` is now truncated to a maximum of 4 lines. This is to support article card design requirements.

I confirmed these changes are working as expected, with the stricter filtering leading to a more focused (and potentially smaller) set of stories.