### PR TITLE
Fix: Correct card border and remove top green bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,19 +50,8 @@ main {
         0 8px 25px -8px rgba(0, 0, 0, 0.15),
         0 4px 10px -4px rgba(0, 0, 0, 0.1),
         inset 0 1px 0 rgba(255, 255, 255, 0.9);
-    border: 2px solid rgba(255, 255, 255, 0.8);
+    border: 1px solid #d1d5db;
     position: relative;
-}
-
-.card::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 2px;
-    background: linear-gradient(90deg, rgba(16, 185, 129, 0.3), rgba(16, 185, 129, 0.6), rgba(16, 185, 129, 0.3));
-    z-index: 1;
 }
 
 .card:hover {
@@ -71,7 +60,7 @@ main {
         0 20px 40px -10px rgba(0, 0, 0, 0.2),
         0 8px 16px -4px rgba(0, 0, 0, 0.1),
         inset 0 1px 0 rgba(255, 255, 255, 0.9);
-    border-color: rgba(16, 185, 129, 0.4);
+    border-color: var(--florida-light-green);
 }
 
 .tab-active {


### PR DESCRIPTION
- Removed the .card::before pseudo-element that was creating a 2px green bar at the top of story cards.
- Changed the .card border to a 1px solid light gray (#d1d5db) for a cleaner look.
- Updated the .card:hover border-color to use the theme variable --florida-light-green for consistency.

These changes address your feedback regarding an "odd green bar" and a "messed up" border on story cards.